### PR TITLE
Feature/mg carpet requirejs deps

### DIFF
--- a/examples/amd/index.html
+++ b/examples/amd/index.html
@@ -17,6 +17,8 @@
       </ul>
     </nav>
 
+    <!-- Global libraries -->
+    <script src="../../src/carpet.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.18/require.min.js"></script>
     <script src="require-config.js"></script>
     <script src="init.js"></script>

--- a/examples/amd/init.js
+++ b/examples/amd/init.js
@@ -1,4 +1,4 @@
-require(['carpet', 'modules/require-module'], function (Carpet) {
+require(['modules/require-module'], function () {
 	'use strict';
 
 	Carpet.init();

--- a/examples/amd/modules/require-module.js
+++ b/examples/amd/modules/require-module.js
@@ -1,9 +1,6 @@
-define(['carpet'], function (Carpet) {
+Carpet.module('require-module', ['modules/test'], function (exports, settings, context, deps) {
   'use strict';
-  Carpet.module('require-module', function (exports, settings, context) {
-
-    exports.init = function () {
-      console.log(arguments, settings, context);
-    };
-  });
+  exports.init = function () {
+    console.log(exports, settings, context, deps);
+  };
 });

--- a/examples/amd/modules/test.js
+++ b/examples/amd/modules/test.js
@@ -1,0 +1,5 @@
+define(function () {
+	return {
+		'test': 1
+	};
+});

--- a/examples/amd/require-config.js
+++ b/examples/amd/require-config.js
@@ -1,5 +1,7 @@
 require.config({
-    paths: {
-        carpet: '../../src/carpet'
+    shim: {
+    	carpet: {
+    		exports: 'Carpet'
+    	}
     }
 });

--- a/examples/minimal-application/modules/navigation.js
+++ b/examples/minimal-application/modules/navigation.js
@@ -1,4 +1,4 @@
-Carpet.module('navigation', function (exports, settings, context) {
+Carpet.module('navigation', function (exports, settings, context, deps) {
   'use strict';
 
   exports.init = function () {

--- a/src/carpet.js
+++ b/src/carpet.js
@@ -3,7 +3,8 @@
 
   if (typeof define === 'function' && define.amd) {
     define(factory);
-  } else {
+  }
+  else {
     root.Carpet = factory();
   }
 }(this, function () {
@@ -339,7 +340,7 @@
         requireWrap = (window.require) ? window.require : function (deps, callback) { callback(); };
 
         moduleInit = function (currentModule) {
-          var args = Array.prototype.slice.call(arguments, 1);
+          var args = arraySlice.call(arguments, 1);
 
           currentModule.moduleBody.call(currentModule, currentModule.methods, currentModule.settings, domModule, args);
 


### PR DESCRIPTION
Carpet.js prototype of dependencies
- Able to work similar to require.js with async components
- Can be easily shimmed like for example jQuery

Sample use:

``` js
Carpet.module('require-module', ['modules/test'], function (exports, settings, context, deps) {
  'use strict';
  exports.init = function () {
    console.log(deps); // => [{test: 1}]
  };
});
```

``` js
modules/test:
define(function () {
  return {
    'test': 1
  };
});
```

![requirejs](https://cloud.githubusercontent.com/assets/628992/9236675/6ffb40d6-4146-11e5-88b8-e56cddb70be4.png)
